### PR TITLE
99 feature code coverage for c++

### DIFF
--- a/.github/workflows/lint_build_test.yml
+++ b/.github/workflows/lint_build_test.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: cd backend_test && ./test_run.sh
+      - run: cd backend_test && ./gcov_run.sh
 
   frontend-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_build_test.yml
+++ b/.github/workflows/lint_build_test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: cd backend_test && ./test_run.sh
-      - run: cd backend_test && ./gcov_run.sh
+      - run: cd backend_test && ./gcov_run.sh -git
 
   frontend-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ test_runner
 
 #local test results
 coverage
+res/

--- a/README.md
+++ b/README.md
@@ -151,12 +151,18 @@ Note that the script might need to be set as a runnable with
 chmod +x test_run.sh
 ```
 
-#### Run manually
-1. Navigate to the backend_test folder
-2. ```emcmake cmake .```
-3. ```emmake cmake --build .```
-4. Rename test_runner.js to test_runner.cjs (I'm looking for ways to circumvent this)
-5. ```node test_runner.cjs```
+## Generating code coverage for the backend
+To simply check the percentage of code run in file_handler.cpp just run the following command in the ```backend_test/``` folder. It also runs automatically in Git after every push. A bash shell and GCC/G++ is needed for the script.
+```bash
+./gcov_run.sh -git
+```
+To generate a full report, including data about specific functions and lines, LCOV must be installed on the system. It should be available in most package managers for both Linux and Mac. Once it is installed, run the following command:
+```bash
+./gcov_run.sh
+```
+Afterwards, navigate to the ```backend_test/res/``` folder and open ```index.html``` in a browser to see the full report.
+
+*Note*: This does not work with CMake hence whý the solution is hard coded. The scripts would need to be modified if new source files are added.
    
 ## Testing the frontend
 The tests run in GitHub Actions on each push to the repo.

--- a/backend_test/gcov_run.sh
+++ b/backend_test/gcov_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+FILE_PATH="../src/cpp"
+
+g++ -fprofile-arcs -ftest-coverage  $FILE_PATH/test_framework/test_init.cpp $FILE_PATH/tests/file_handler_test.cpp -o code_cov
+./code_cov
+gcov code_cov-file_handler_test.cpp
+lcov --capture --directory . --output-file=coverage.info
+genhtml coverage.info --output-directory=res
+
+rm *.gcov
+rm *.gcda
+rm *.gcno
+rm code_cov
+rm coverage.info

--- a/backend_test/gcov_run.sh
+++ b/backend_test/gcov_run.sh
@@ -2,13 +2,18 @@
 FILE_PATH="../src/cpp"
 
 g++ -fprofile-arcs -ftest-coverage  $FILE_PATH/test_framework/test_init.cpp $FILE_PATH/tests/file_handler_test.cpp -o code_cov
-./code_cov
-gcov code_cov-file_handler_test.cpp
-lcov --capture --directory . --output-file=coverage.info
-genhtml coverage.info --output-directory=res
+./code_cov > /dev/null
+
+if [[ $1 = "-git" ]]
+then
+    gcov code_cov-file_handler_test.cpp | grep -A1 src/cpp/file_handler.cpp
+else
+    lcov --capture --directory . --output-file=coverage.info
+    genhtml coverage.info --output-directory=res
+    rm coverage.info
+fi
 
 rm *.gcov
 rm *.gcda
 rm *.gcno
 rm code_cov
-rm coverage.info


### PR DESCRIPTION
Added functionality for generating code coverage for the backend. Sadly, it doesn't seem to work with CMake, hence why I hard coded a solution. There is documentation in the README that specifies how it should be run to create an extensive local report. A simple report will also be created automatically in GitHub with every push. 