### PR TITLE
76 add types for filehandler module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,6 +84,7 @@
     "dist/**",
     "public/**",
     "assets/**",
-    "**/CMakeFiles/**"
+    "**/CMakeFiles/**",
+    "FileHandler.d.ts"
   ]
 }

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -16,6 +16,7 @@ import {
 } from 'victory';
 import { TextProps } from 'victory-core';
 import { Site } from './SiteInterface';
+import { FileHandler } from './FileHandler';
 /**
  * Top level component.
  *
@@ -30,7 +31,7 @@ interface ChartProps {
   metrics: Array<string>;
   sites: Array<string>;
   siteProps: Map<string, Site>;
-  fileHandler: any;
+  fileHandler: FileHandler;
 }
 
 /**
@@ -327,7 +328,7 @@ function CustomTickLabelBoxPlot(props: CustomTickLabelProps): JSX.Element {
  * @param fileHandler filehandler to get data from backend
  * @returns a map with siteId as key and the data as value
  */
-function useBoxDiagrams(siteIds: string[], fileHandler: any) {
+function useBoxDiagrams(siteIds: string[], fileHandler: FileHandler) {
   return useMemo(() => {
     const histograms: Map<string, string> = new Map();
     siteIds.forEach((id) =>
@@ -550,7 +551,7 @@ function drawHistogram(
  */
 function useHistograms(
   siteIds: string[],
-  fileHandler: any
+  fileHandler: FileHandler
 ): Map<string, string> {
   return useMemo(() => {
     const histograms: Map<string, string> = new Map();

--- a/src/components/FileHandler.d.ts
+++ b/src/components/FileHandler.d.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+/**
+ * @file declares cpp module FileHandler
+ */
+export class FileHandler extends React.Component<any> {
+  /**
+   * @brief Get the histogram for a given site
+   * @param site_id The site id
+   */
+  GetHistogram(id: string): Map<string, string>;
+  /**
+   * @brief Get the box diagram for a given site
+   * @param site_id The site id
+   */
+  GetBoxDiagram(id: string): Map<string, string>;
+  /**
+   * @brief Add a file to the FileHandler's buffer
+   * @param file The content of the file
+   * @param file_name  The name of the file
+   */
+  AddFile(result: any, file: any);
+  /**
+   * @brief Get the names and ids of all the sites
+   * @returns std::vector<std::string> The names of the sites
+   */
+  GetSites(): string;
+  /**
+   * @brief Get the metrics for all sites.
+   * @returns std::string The metrics
+   */
+  GetMetrics(): string;
+  /**
+   * @brief Go through the uploaded files and link the hosts to the corresponding performance files
+   */
+  ComputeFiles(): void;
+}

--- a/src/components/FileHandler.d.ts
+++ b/src/components/FileHandler.d.ts
@@ -7,7 +7,7 @@ export class FileHandler extends React.Component<any> {
    * @brief Get the histogram for a given site
    * @param site_id The site id
    */
-  GetHistogram(id: string): Map<string, string>;
+  GetHistogram(id: string): string;
   /**
    * @brief Get the box diagram for a given site
    * @param site_id The site id

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -18,6 +18,7 @@ import LegendBar from './LegendBar';
 import CHART_COLORS from './CHART_COLORS';
 import Dropdown from './Dropdown';
 import { Site } from './SiteInterface';
+import { FileHandler } from './FileHandler';
 import '../App.css';
 
 const size = 75;
@@ -77,7 +78,7 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 
 interface MenuProps {
   // TODO: Get the actual type
-  fileHandler: any;
+  fileHandler: FileHandler;
   siteProps: Map<string, Site>;
   setSiteProps: Dispatch<React.SetStateAction<Map<string, Site>>>;
   setMetricProps: Dispatch<React.SetStateAction<string[]>>;
@@ -89,7 +90,7 @@ interface MenuProps {
  * @param files files which are added to the backend
  * @param fileHandler is used to add the files to the backend
  */
-export const addFilesToBackend = (files: File[], fileHandler: any) => {
+export const addFilesToBackend = (files: File[], fileHandler: FileHandler) => {
   if (files.length > 0) {
     files.forEach((file) => {
       const filereader = new FileReader();
@@ -112,7 +113,7 @@ export const addFilesToBackend = (files: File[], fileHandler: any) => {
  * @param fileHandler used to get the site names
  * @returns an array of site names
  */
-const getSites = (fileHandler: any): Site[] => {
+const getSites = (fileHandler: FileHandler): Site[] => {
   const sites = fileHandler ? JSON.parse(fileHandler.GetSites()).sites : [];
   return sites;
 };
@@ -123,7 +124,7 @@ const getSites = (fileHandler: any): Site[] => {
  * @param fileHandler used to get the metrics
  * @returns an array of metrics
  */
-const getMetrics = (fileHandler: any): string[] => {
+const getMetrics = (fileHandler: FileHandler): string[] => {
   const metrics = fileHandler
     ? JSON.parse(fileHandler.GetMetrics()).metrics
     : [];


### PR DESCRIPTION
We think the task is done. We don't know if this is a good or the correct solution but it seems to be working. There is no more "fileHandler : any" so problem solved? :)

Note: es-lint was not happy about the addition of the .d.ts file, so we disabled it for this file. This should not be a major problem.