### PR TITLE
110 bug backend erases performance files from cache

### DIFF
--- a/src/cpp/file_handler.cpp
+++ b/src/cpp/file_handler.cpp
@@ -111,12 +111,7 @@ std::string FileHandler::GetInfoBox(std::string site_id) {
 
 std::string FileHandler::GetHistogram(std::string site_id) const
 {
-    // Make sure the site exists
-    if (sites.find(site_id) == sites.end())
-    {
-#ifdef DEBUG
-        std::cout << "Could not find site with id " << site_id << std::endl;
-#endif
+    if (!isSiteValid(site_id)) {
         return "{}";
     }
 
@@ -130,12 +125,7 @@ std::string FileHandler::GetHistogram(std::string site_id) const
 
 std::string FileHandler::GetBoxDiagram(std::string site_id) const
 {
-    // Make sure the site exists
-    if (sites.find(site_id) == sites.end())
-    {
-#ifdef DEBUG
-        std::cout << "Could not find site with id " << site_id << std::endl;
-#endif
+    if (!isSiteValid(site_id)) {
         return "{}";
     }
 
@@ -155,6 +145,30 @@ std::string FileHandler::GetBoxDiagram(std::string site_id) const
         box_diagram[el.key()]["max"] = GetBoxMax(el.value());
     }
     return box_diagram.dump();
+}
+
+bool FileHandler::isSiteValid(std::string site_id) const 
+{
+    auto site_it = sites.find(site_id);
+
+    // Check if the site exists
+    if (site_it == sites.end())
+    {
+#ifdef DEBUG
+        std::cout << "Could not find site with id " << site_id << std::endl;
+#endif
+        return false;
+    }
+
+    if (site_it->second.logs.empty())
+    {
+#ifdef DEBUG
+        std::cout << "Could not found any performance data for site with id " << site_id << std::endl;
+#endif
+        return false;
+    }
+    
+    return true;
 }
 
 void FileHandler::CalculateCategories(struct Site &site, json &categories) const

--- a/src/cpp/file_handler.cpp
+++ b/src/cpp/file_handler.cpp
@@ -35,13 +35,22 @@ void FileHandler::ComputeFiles()
         AddHostFile(file.file);
     }
 
-    for (auto file : performance_files)
+    auto file_it = performance_files.begin();
+
+    // Only remove the performance files that were actually added
+    while (file_it != performance_files.end())
     {
-        AddPerformanceFile(file.file, file.name);
+        if (AddPerformanceFile(file_it->file, file_it->name))
+        {
+            performance_files.erase(file_it++);
+        } 
+        else 
+        {
+            file_it++;
+        }
     }
 
     host_files = {};
-    performance_files = {};
 
 #ifdef DEBUG
     std::cout << "Linked the host and performance files." << std::endl;
@@ -399,7 +408,7 @@ json FileHandler::GetPerformanceJson(std::string &content) const
     return performance;
 }
 
-void FileHandler::AddPerformanceFile(std::string &file, std::string &file_name)
+bool FileHandler::AddPerformanceFile(std::string &file, std::string &file_name)
 {
     std::string site_id = GetIdFromPerformance(file_name);
     // Add the host to the corresponding site if it exists
@@ -412,13 +421,12 @@ void FileHandler::AddPerformanceFile(std::string &file, std::string &file_name)
 #ifdef DEBUG
         std::cout << "Linked log " << file_name << " to " << site_id << "." << std::endl;
 #endif
+        return true;
     }
-    else
-    {
 #ifdef DEBUG
         std::cout << "The site with id " << site_id << " does not exist." << std::endl;
 #endif
-    }
+    return false;
 }
 
 std::string FileHandler::GetIdFromPerformance(std::string &file_name) const

--- a/src/cpp/file_handler.h
+++ b/src/cpp/file_handler.h
@@ -179,12 +179,21 @@ public:
      * @return std::string 
      */
     std::string GetIdFromPerformance(std::string &file_name) const;
+
     void ParseContent(std::string &fileContent, std::regex &regex, std::vector<std::string> &result) const;
 
     json GetPerformanceJson(std::string &content) const;
 
     void SplitString(std::string &s, std::string &delim,
                      std::vector<std::string>) const;
+
+    /**
+     * @brief Check if a site is valid for calculations
+     *
+     * @param site_id The site id
+     * @return bool If it is valid or not
+     */
+    bool isSiteValid(std::string site_id) const;
 };
 
 #ifndef _TESTING_

--- a/src/cpp/file_handler.h
+++ b/src/cpp/file_handler.h
@@ -6,6 +6,7 @@
 #include "nlohmann/json.h"
 #include <regex>
 #include <set>
+#include <list>
 
 #ifndef _TESTING_
 #include <emscripten/bind.h>
@@ -78,7 +79,7 @@ public:
   private:
     std::unordered_map<std::string, struct Site> sites;
     std::vector<struct LoadedFile> host_files; 
-    std::vector<struct LoadedFile> performance_files; 
+    std::list<struct LoadedFile> performance_files; 
     
     void CalculateCategories(struct Site &site, json &categories) const;
 
@@ -169,8 +170,9 @@ public:
      * 
      * @param file The content of the performance file
      * @param file_name  The file name
+     * @return bool If the file was added
      */
-    void AddPerformanceFile(std::string &file, std::string &file_name);
+    bool AddPerformanceFile(std::string &file, std::string &file_name);
 
     /**
      * @brief Get the id from the performance file

--- a/src/cpp/tests/file_handler_test.cpp
+++ b/src/cpp/tests/file_handler_test.cpp
@@ -240,5 +240,25 @@ TEST_CASE("FileHandler") {
         CHECK(info_box["hosts"] == 2);
     }
 
+    SUBCASE("Caching between computes") {
+        std::string performance =
+            "response_time_bucket{method=\"Test\",le=\"1\"} 1\n"
+            "response_time_bucket{method=\"Test1\",le=\"6\"} 1\n"
+            "response_time_bucket{method=\"Test2\",le=\"6\"} 1\n";
+
+        std::string performance_name = "test1_230102.txt";
+
+        fh->AddFile(performance, performance_name);
+        fh->ComputeFiles();
+
+        std::string host = "{\"site_name\": \"test\", \"site_id\": \"test1\"}";
+        std::string host_name = "test.json";
+
+        fh->AddFile(host, host_name);
+        fh->ComputeFiles();
+
+        CHECK(fh->GetHistogram("test1") != "{}");
+    }
+
     delete fh;
 }


### PR DESCRIPTION
Performance files will only be removed from the cache once they have been linked. This means that they can now be uploaded separately from the sites